### PR TITLE
Update to inspektor 0.2.0

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,5 +1,5 @@
 pep8==1.6.2
-inspektor==0.1.16
+inspektor==0.2.0
 autotest==0.16.2
 aexpect==1.0.0
 simplejson==3.8.0

--- a/virttest/defaults.py
+++ b/virttest/defaults.py
@@ -1,7 +1,4 @@
-from avocado.utils import distro
-
 DEFAULT_MACHINE_TYPE = "i440fx"
-DEFAULT_GUEST_OS = None     # populated below
 
 
 def get_default_guest_os_info():
@@ -12,3 +9,6 @@ def get_default_guest_os_info():
 
 
 DEFAULT_GUEST_OS = get_default_guest_os_info()['variant']
+
+__all__ = ['DEFAULT_MACHINE_TYPE', 'DEFAULT_GUEST_OS',
+           'get_default_guest_os_info']

--- a/virttest/libvirt_xml/vm_xml.py
+++ b/virttest/libvirt_xml/vm_xml.py
@@ -5,8 +5,6 @@ http://libvirt.org/formatdomain.html
 
 import logging
 
-from avocado.utils import process
-
 from .. import xml_utils
 from .. import utils_misc
 from ..libvirt_xml import base, accessors, xcepts


### PR DESCRIPTION
The new release of inspektor 0.2.0 by default will alert us of unused imports.
