### PR TITLE
Create MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,16 @@
+Avocado-vt maintainers
+======================
+
+The intention of this file is not to establish who owns what portions of the
+code base, but to provide a set of names that developers can consult when they
+have a question about a particular subset and also to provide a set of names
+you can look for on github for any pull requests you might want to get approved.
+
+In general, if you have a question, you should send an email to the Virt Test
+development mailing list and not any specific individual privately.
+
+L: Avocado-devel <avocado-devel@redhat.com>
+M: Yanbing Du <ydu@redhat.com>
+M: Jiangang Wei <weijg.fnst@cn.fujitsu.com>
+M: Guannan Wayne Sun <gsun@redhat.com>
+M: Hao Liu <hliu@redhat.com>


### PR DESCRIPTION
There used to be MAINTAINERS file in virttest, but it was not transfered.
This commit uses active volunteers with commit rights from the community.

I'd like to ask the majority of these people for confirmation (hopefully I used the right GH name).
Most active from the last year: @lmr @xutian @ldoktor @clebergnu @will-Do
Ex virttest maintainers: @lmr @clebergnu @jzupka @ldoktor @ypu @FengYang @cevich @yumingfei @yangdongsheng @leonstack @chuanchang
